### PR TITLE
FIX Pixel fonts: Use stbtt_ScaleForMappingEmToPixels

### DIFF
--- a/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSettings.cs
+++ b/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSettings.cs
@@ -5,5 +5,6 @@
 		public int KernelWidth;
 		public int KernelHeight;
 		public bool UseOldRasterizer;
+		public bool UseEmToPixelsScale;
 	}
 }

--- a/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
+++ b/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
@@ -56,7 +56,7 @@ namespace FontStashSharp.Rasterizers.StbTrueTypeSharp
 			GC.SuppressFinalize(this);
 		}
 
-		private float CalculateScale(float size) => stbtt_ScaleForPixelHeight(_font, size);
+		private float CalculateScale(float size) => stbtt_ScaleForMappingEmToPixels(_font, size);
 
 		public void GetMetricsForSize(float fontSize, out int ascent, out int descent, out int lineHeight)
 		{

--- a/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
+++ b/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
@@ -124,7 +124,7 @@ namespace FontStashSharp.Rasterizers.StbTrueTypeSharp
 
 		public float CalculateScaleForTextShaper(float fontSize)
 		{
-			return stbtt_ScaleForPixelHeight(_font, fontSize);
+			return stbtt_ScaleForMappingEmToPixels(_font, fontSize);
 		}
 	}
 }

--- a/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
+++ b/src/FontStashSharp.Rasterizers.StbTrueTypeSharp/StbTrueTypeSharpSource.cs
@@ -56,7 +56,7 @@ namespace FontStashSharp.Rasterizers.StbTrueTypeSharp
 			GC.SuppressFinalize(this);
 		}
 
-		private float CalculateScale(float size) => stbtt_ScaleForMappingEmToPixels(_font, size);
+		private float CalculateScale(float size) => _settings.UseEmToPixelsScale ? stbtt_ScaleForMappingEmToPixels(_font, size) : stbtt_ScaleForPixelHeight(_font, size);
 
 		public void GetMetricsForSize(float fontSize, out int ascent, out int descent, out int lineHeight)
 		{
@@ -122,9 +122,6 @@ namespace FontStashSharp.Rasterizers.StbTrueTypeSharp
 			return (int)(result * scale);
 		}
 
-		public float CalculateScaleForTextShaper(float fontSize)
-		{
-			return stbtt_ScaleForMappingEmToPixels(_font, fontSize);
-		}
+		public float CalculateScaleForTextShaper(float fontSize) => _settings.UseEmToPixelsScale ? stbtt_ScaleForMappingEmToPixels(_font, fontSize) : stbtt_ScaleForPixelHeight(_font, fontSize);
 	}
 }


### PR DESCRIPTION
Fix for #4, I noticed the second usage of `stbtt_ScaleForPixelHeight` in `CalculateScaleForTextShaper` but honestly I have not tested the text shaping path in this setup


